### PR TITLE
close検知 実装

### DIFF
--- a/data/control/advancements/close-ender_chest.json
+++ b/data/control/advancements/close-ender_chest.json
@@ -1,0 +1,19 @@
+{
+  "criteria": {
+    "close": {
+      "trigger": "inventory_changed",
+      "conditions": {
+        "player": [
+        ],
+        "items": [
+          {
+            "nbt": "{EnderChestClose:true}"
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "control:close-ender_chest"
+  }
+}

--- a/data/control/functions/close-ender_chest.mcfunction
+++ b/data/control/functions/close-ender_chest.mcfunction
@@ -3,8 +3,8 @@
 # エンダーチェストを閉じたとき処理
 #
 
-scoreboard players reset @s EnderChestClose
 tag @s remove CtrlEnderChest
+clear @s stone_button{EnderChestClose:true}
 
 ## 余分なアイテムを返却
 function control:item_set/clear
@@ -14,4 +14,4 @@ execute if predicate control:low run clone ~-3 0 ~-3 ~3 ~3 ~3 ~-3 0 ~-3 filtered
 execute if predicate control:high run clone ~-3 ~-3 ~-3 ~3 255 ~3 ~-3 ~-3 ~-3 filtered minecraft:ender_chest force
 execute unless predicate control:low unless predicate control:high run clone ~-3 ~-3 ~-3 ~3 ~3 ~3 ~-3 ~-3 ~-3 filtered minecraft:ender_chest force
 
-schedule clear control:tick
+advancement revoke @s only control:close-ender_chest

--- a/data/control/functions/define.mcfunction
+++ b/data/control/functions/define.mcfunction
@@ -6,7 +6,6 @@
 
 #> ScoreBoard-Object
 #define objective CtrlEnderChest
-#define objective EnderChestClose
 
 #> Tags
 #define tag CtrlEnderChest

--- a/data/control/functions/initialize.mcfunction
+++ b/data/control/functions/initialize.mcfunction
@@ -2,4 +2,3 @@
 
 ## スコアボード
 scoreboard objectives add CtrlEnderChest minecraft.custom:open_enderchest
-scoreboard objectives add EnderChestClose custom:walk_one_cm

--- a/data/control/functions/item_set/clear.mcfunction
+++ b/data/control/functions/item_set/clear.mcfunction
@@ -22,4 +22,3 @@ execute as @e[type=item,nbt={Age:0s}] run data modify entity @s PickupDelay set 
 ## 空にする
 data modify block 1 1 1 Items set value []
 loot replace entity @s enderchest.0 27 mine 1 1 1 debug_stick
-

--- a/data/control/functions/open-ender_chest.mcfunction
+++ b/data/control/functions/open-ender_chest.mcfunction
@@ -12,12 +12,13 @@ execute if entity @s[gamemode=!creative] run function control:item_set/no-creati
 execute if entity @s[gamemode=creative] run function control:item_set/select
 
 ## メニュー操作中タグ付与
-tp ~ ~ ~
-scoreboard players reset @s EnderChestClose
 tag @s add CtrlEnderChest
 
 ## メニュー操作tick起動
-function control:tick
+schedule function control:tick 1t
+
+## close検知準備
+item replace entity @s armor.head with stone_button{EnderChestClose:true}
 
 scoreboard players reset @s CtrlEnderChest
 advancement revoke @s only control:open-ender_chest

--- a/data/control/functions/tick.mcfunction
+++ b/data/control/functions/tick.mcfunction
@@ -3,9 +3,6 @@
 # schedule tick loop
 #
 
-## エンダーチェストclose
-execute as @a[tag=CtrlEnderChest,scores={EnderChestClose=100..}] at @s run function control:close-ender_chest
-
 ## メニューアイテム選択
 execute as @a store success score @s CtrlEnderChest run clear @s #control:all{CtrlEnderChest:true} 0
 execute as @a[scores={CtrlEnderChest=1}] at @s run function control:menu_click


### PR DESCRIPTION
# エンダーチェストのclose検知の実装
歩行スコアを用いた疑似的なclose検知では不具合が多かった。  
エンダーチェストを閉じた瞬間を検知することで、安定かつ不具合をなくすことができる。

## inventory_changedとエンダーチェスト
エンダーチェストを開いた状態でインベントリにアイテムを設置しても、閉じるまで inventory_changed はトリガーされない。  
しかし、アイテム設置後の開いている状態でclearや他のインベントリ操作をしてしまうと inventory_changed がトリガーされてしまう。

## 解決方法
特定のNBT(今回は`EnderChestClose`タグ)が付与されたアイテムを設置し、 inventory_changed ではそのNBTをチェックする条件を追加した。  
これによりそのNBTを持っていないアイテムによるインベントリ操作でトリガーされることはなくなる。  
また、赤石愛氏の[X9EnderChest](https://github.com/Ai-Akaishi/X9EnderChest)で用いられていたようなスコアも必要ないことが分かった。
