### PR TITLE
Ponpon/game rule menu add

### DIFF
--- a/data/control/functions/menus/game_settings/game_rules/commandblock_output/act/0.mcfunction
+++ b/data/control/functions/menus/game_settings/game_rules/commandblock_output/act/0.mcfunction
@@ -1,0 +1,10 @@
+#> control:menus/game_settings/game_rules/commandblock_output/act/0
+#
+# 設定を変更したり、アイコンの内容を変更したりする
+#
+
+## ゲームルールを切り替え
+execute store result storage common: Success byte 1 run gamerule commandBlockOutput
+
+execute if data storage common: {Success:true} run gamerule commandBlockOutput false
+execute if data storage common: {Success:false} run gamerule commandBlockOutput true

--- a/data/control/functions/menus/game_settings/game_rules/commandblock_output/check.mcfunction
+++ b/data/control/functions/menus/game_settings/game_rules/commandblock_output/check.mcfunction
@@ -1,0 +1,6 @@
+#> control:menus/game_settings/game_rules/commandblock_output/check
+
+## このメニューが選ばれたら処理を実行
+execute unless score @s CtrlEnderChest matches 1 store success score @s CtrlEnderChest run clear @s #control:all{JumpTo:"GameRules.commandBlockOutput"} 0
+execute if score @s CtrlEnderChest matches 1 run function control:menus/game_settings/game_rules/commandblock_output/act/0
+scoreboard players set @s[scores={CtrlEnderChest=1}] CtrlEnderChest 2

--- a/data/control/functions/menus/game_settings/game_rules/commandblock_output/close/0.mcfunction
+++ b/data/control/functions/menus/game_settings/game_rules/commandblock_output/close/0.mcfunction
@@ -1,0 +1,4 @@
+#> control:menus/game_settings/game_rules/commandblock_output/close/0
+#
+# エンダーチェストを閉じた時に実行したいコマンドを記述
+#

--- a/data/control/functions/menus/game_settings/game_rules/commandblock_output/close_check.mcfunction
+++ b/data/control/functions/menus/game_settings/game_rules/commandblock_output/close_check.mcfunction
@@ -1,0 +1,7 @@
+#> control:menus/game_settings/game_rules/commandblock_output/close_check
+#
+# エンダーチェストを閉じた時に実行したいときのみ有効化する
+#
+
+## チェック
+#function control:menus/game_settings/game_rules/commandblock_output/close/0

--- a/data/control/functions/menus/game_settings/game_rules/commandblock_output/initialize.mcfunction
+++ b/data/control/functions/menus/game_settings/game_rules/commandblock_output/initialize.mcfunction
@@ -1,0 +1,26 @@
+#> control:menus/game_settings/game_rules/commandblock_output/initialize
+#
+# メニューのページ、位置、アイコン、説明などを設定
+#
+
+# 初期化
+data remove storage control:menu Initialize
+data modify storage control:menu Initialize set value {tag:{CtrlEnderChest:true,JumpTo:"GameRules.commandBlockOutput"},Count:1b}
+
+## アイコンとなるアイテムを指定
+data modify storage control:menu Initialize.id set value "minecraft:command_block"
+
+## メニューの名前(JP)を指定
+data modify storage control:menu Initialize.tag.display.Name set value '{"text":"commandBlockOutput","bold":true}'
+
+## 説明文を指定(任意)
+data modify storage control:menu Initialize.tag.display.Lore set value ['{"text":"コマンドブロックの実行ログを表示する","color":"white","italic":false}','{"text":""}']
+
+## 表示するスロット番号を指定 byte型
+data modify storage control:menu Initialize.Slot set value 0b
+
+## その他追加したい情報を指定(任意)
+#data modify storage control:menu Initialize.tag merge value {}
+
+## 追加先のメニューページを指定(変更は任意)
+data modify storage control:menu Menus.GameRules append from storage control:menu Initialize

--- a/data/control/functions/menus/game_settings/game_rules/commandblock_output/modify/0.mcfunction
+++ b/data/control/functions/menus/game_settings/game_rules/commandblock_output/modify/0.mcfunction
@@ -1,0 +1,12 @@
+#> control:menus/game_settings/game_rules/commandblock_output/modify/0
+#
+# メニューアイコンの内容を編集する
+# 一時的な変更はここで変更する
+# control: Item がメニューアイコンのアイテムデータ
+#
+
+## ゲームルールの現在の状態を表示
+execute store result storage common: Success byte 1 run gamerule commandBlockOutput
+
+execute if data storage common: {Success:true} run data modify storage control: Item.tag.display.Lore[1] set value '[{"text":"現在の状態: ","color":"white","italic":false},{"text":"有効","color":"green","bold":true}]'
+execute if data storage common: {Success:false} run data modify storage control: Item.tag.display.Lore[1] set value '[{"text":"現在の状態: ","color":"white","italic":false},{"text":"無効","color":"red","bold":true}]'

--- a/data/control/functions/menus/game_settings/game_rules/commandblock_output/modify_check.mcfunction
+++ b/data/control/functions/menus/game_settings/game_rules/commandblock_output/modify_check.mcfunction
@@ -1,0 +1,7 @@
+#> control:menus/game_settings/game_rules/commandblock_output/modify_check
+#
+# メニューアイコンの内容を編集したいときのみ有効化する
+#
+
+## アイテムチェック
+execute if data storage control: Item.tag{JumpTo:"GameRules.commandBlockOutput"} run function control:menus/game_settings/game_rules/commandblock_output/modify/0

--- a/data/control/functions/menus/game_settings/game_rules/send_command_feedback/act/0.mcfunction
+++ b/data/control/functions/menus/game_settings/game_rules/send_command_feedback/act/0.mcfunction
@@ -1,0 +1,10 @@
+#> control:menus/game_settings/game_rules/send_command_feedback/act/0
+#
+# 設定を変更したり、アイコンの内容を変更したりする
+#
+
+## ゲームルールを切り替え
+execute store result storage common: Success byte 1 run gamerule sendCommandFeedback
+
+execute if data storage common: {Success:true} run gamerule sendCommandFeedback false
+execute if data storage common: {Success:false} run gamerule sendCommandFeedback true

--- a/data/control/functions/menus/game_settings/game_rules/send_command_feedback/check.mcfunction
+++ b/data/control/functions/menus/game_settings/game_rules/send_command_feedback/check.mcfunction
@@ -1,0 +1,6 @@
+#> control:menus/game_settings/game_rules/send_command_feedback/check
+
+## このメニューが選ばれたら処理を実行
+execute unless score @s CtrlEnderChest matches 1 store success score @s CtrlEnderChest run clear @s #control:all{JumpTo:"GameRules.sendCommandFeedback"} 0
+execute if score @s CtrlEnderChest matches 1 run function control:menus/game_settings/game_rules/send_command_feedback/act/0
+scoreboard players set @s[scores={CtrlEnderChest=1}] CtrlEnderChest 2

--- a/data/control/functions/menus/game_settings/game_rules/send_command_feedback/close/0.mcfunction
+++ b/data/control/functions/menus/game_settings/game_rules/send_command_feedback/close/0.mcfunction
@@ -1,0 +1,4 @@
+#> control:menus/game_settings/game_rules/send_command_feedback/close/0
+#
+# エンダーチェストを閉じた時に実行したいコマンドを記述
+#

--- a/data/control/functions/menus/game_settings/game_rules/send_command_feedback/close_check.mcfunction
+++ b/data/control/functions/menus/game_settings/game_rules/send_command_feedback/close_check.mcfunction
@@ -1,0 +1,7 @@
+#> control:menus/game_settings/game_rules/send_command_feedback/close_check
+#
+# エンダーチェストを閉じた時に実行したいときのみ有効化する
+#
+
+## チェック
+#function control:menus/game_settings/game_rules/send_command_feedback/close/0

--- a/data/control/functions/menus/game_settings/game_rules/send_command_feedback/initialize.mcfunction
+++ b/data/control/functions/menus/game_settings/game_rules/send_command_feedback/initialize.mcfunction
@@ -1,0 +1,26 @@
+#> control:menus/game_settings/game_rules/send_command_feedback/initialize
+#
+# メニューのページ、位置、アイコン、説明などを設定
+#
+
+# 初期化
+data remove storage control:menu Initialize
+data modify storage control:menu Initialize set value {tag:{CtrlEnderChest:true,JumpTo:"GameRules.sendCommandFeedback"},Count:1b}
+
+## アイコンとなるアイテムを指定
+data modify storage control:menu Initialize.id set value "minecraft:command_block"
+
+## メニューの名前(JP)を指定
+data modify storage control:menu Initialize.tag.display.Name set value '{"text":"sendCommandFeedback","bold":true}'
+
+## 説明文を指定(任意)
+data modify storage control:menu Initialize.tag.display.Lore set value ['{"text":"プレイヤーのコマンド実行ログを表示する","color":"white","italic":false}','{"text":""}']
+
+## 表示するスロット番号を指定 byte型
+data modify storage control:menu Initialize.Slot set value 1b
+
+## その他追加したい情報を指定(任意)
+#data modify storage control:menu Initialize.tag merge value {}
+
+## 追加先のメニューページを指定(変更は任意)
+data modify storage control:menu Menus.GameRules append from storage control:menu Initialize

--- a/data/control/functions/menus/game_settings/game_rules/send_command_feedback/modify/0.mcfunction
+++ b/data/control/functions/menus/game_settings/game_rules/send_command_feedback/modify/0.mcfunction
@@ -1,0 +1,12 @@
+#> control:menus/game_settings/game_rules/send_command_feedback/modify/0
+#
+# メニューアイコンの内容を編集する
+# 一時的な変更はここで変更する
+# control: Item がメニューアイコンのアイテムデータ
+#
+
+## ゲームルールの現在の状態を表示
+execute store result storage common: Success byte 1 run gamerule sendCommandFeedback
+
+execute if data storage common: {Success:true} run data modify storage control: Item.tag.display.Lore[1] set value '[{"text":"現在の状態: ","color":"white","italic":false},{"text":"有効","color":"green","bold":true}]'
+execute if data storage common: {Success:false} run data modify storage control: Item.tag.display.Lore[1] set value '[{"text":"現在の状態: ","color":"white","italic":false},{"text":"無効","color":"red","bold":true}]'

--- a/data/control/functions/menus/game_settings/game_rules/send_command_feedback/modify_check.mcfunction
+++ b/data/control/functions/menus/game_settings/game_rules/send_command_feedback/modify_check.mcfunction
@@ -1,0 +1,7 @@
+#> control:menus/game_settings/game_rules/send_command_feedback/modify_check
+#
+# メニューアイコンの内容を編集したいときのみ有効化する
+#
+
+## アイテムチェック
+execute if data storage control: Item.tag{JumpTo:"GameRules.sendCommandFeedback"} run function control:menus/game_settings/game_rules/send_command_feedback/modify/0

--- a/data/control/functions/menus/return/game_settings/act/0.mcfunction
+++ b/data/control/functions/menus/return/game_settings/act/0.mcfunction
@@ -1,0 +1,7 @@
+#> control:menus/return/game_settings/act/0
+#
+# 設定を変更したり、アイコンの内容を変更したりする
+#
+
+## ゲーム設定画面にセット
+data modify storage control:menu ShowMenu set from storage control:menu Menus.GameSettings

--- a/data/control/functions/menus/return/game_settings/check.mcfunction
+++ b/data/control/functions/menus/return/game_settings/check.mcfunction
@@ -1,0 +1,6 @@
+#> control:menus/return/game_settings/check
+
+## このメニューが選ばれたら処理を実行
+execute unless score @s CtrlEnderChest matches 1 store success score @s CtrlEnderChest run clear @s #control:all{JumpTo:"Return.GameSettings"} 0
+execute if score @s CtrlEnderChest matches 1 run function control:menus/return/game_settings/act/0
+scoreboard players set @s[scores={CtrlEnderChest=1}] CtrlEnderChest 2

--- a/data/control/functions/menus/return/game_settings/close/0.mcfunction
+++ b/data/control/functions/menus/return/game_settings/close/0.mcfunction
@@ -1,0 +1,4 @@
+#> control:menus/return/game_settings/close/0
+#
+# エンダーチェストを閉じた時に実行したいコマンドを記述
+#

--- a/data/control/functions/menus/return/game_settings/close_check.mcfunction
+++ b/data/control/functions/menus/return/game_settings/close_check.mcfunction
@@ -1,0 +1,7 @@
+#> control:menus/return/game_settings/close_check
+#
+# エンダーチェストを閉じた時に実行したいときのみ有効化する
+#
+
+## チェック
+#function control:menus/return/game_settings/close/0

--- a/data/control/functions/menus/return/game_settings/initialize.mcfunction
+++ b/data/control/functions/menus/return/game_settings/initialize.mcfunction
@@ -1,0 +1,26 @@
+#> control:menus/return/game_settings/initialize
+#
+# メニューのページ、位置、アイコン、説明などを設定
+#
+
+# 初期化
+data remove storage control:menu Initialize
+data modify storage control:menu Initialize set value {tag:{CtrlEnderChest:true,JumpTo:"Return.GameSettings"},Count:1b}
+
+## アイコンとなるアイテムを指定
+data modify storage control:menu Initialize.id set value "minecraft:iron_door"
+
+## メニューの名前(JP)を指定
+data modify storage control:menu Initialize.tag.display.Name set value '{"text":"ゲーム設定画面にもどる","color":"dark_gray","bold":true}'
+
+## 説明文を指定(任意)
+#data modify storage control:menu Initialize.tag.display.Lore set value []
+
+## 表示するスロット番号を指定 byte型
+data modify storage control:menu Initialize.Slot set value 26b
+
+## その他追加したい情報を指定(任意)
+#data modify storage control:menu Initialize.tag merge value {}
+
+## 追加先のメニューページを指定(変更は任意)
+data modify storage control:menu Menus.GameRules append from storage control:menu Initialize

--- a/data/control/functions/menus/return/game_settings/modify/0.mcfunction
+++ b/data/control/functions/menus/return/game_settings/modify/0.mcfunction
@@ -1,0 +1,6 @@
+#> control:menus/return/game_settings/modify/0
+#
+# メニューアイコンの内容を編集する
+# 一時的な変更はここで変更する
+# control: Item がメニューアイコンのアイテムデータ
+#

--- a/data/control/functions/menus/return/game_settings/modify_check.mcfunction
+++ b/data/control/functions/menus/return/game_settings/modify_check.mcfunction
@@ -1,0 +1,7 @@
+#> control:menus/return/game_settings/modify_check
+#
+# メニューアイコンの内容を編集したいときのみ有効化する
+#
+
+## アイテムチェック
+#execute if data storage control: Item.tag{JumpTo:"Return.GameSettings"} run function control:menus/return/game_settings/modify/0

--- a/data/control/tags/functions/menu_close.json
+++ b/data/control/tags/functions/menu_close.json
@@ -3,6 +3,7 @@
         "control:menus/show/player_menu/close_check",
         "control:menus/show/game_settings/close_check",
         "control:menus/show/game_rules/close_check",
-        "control:menus/game_settings/game_rules/commandblock_output/close_check"
+        "control:menus/game_settings/game_rules/commandblock_output/close_check",
+        "control:menus/return/game_settings/close_check"
     ]
 }

--- a/data/control/tags/functions/menu_close.json
+++ b/data/control/tags/functions/menu_close.json
@@ -4,6 +4,7 @@
         "control:menus/show/game_settings/close_check",
         "control:menus/show/game_rules/close_check",
         "control:menus/game_settings/game_rules/commandblock_output/close_check",
-        "control:menus/return/game_settings/close_check"
+        "control:menus/return/game_settings/close_check",
+        "control:menus/game_settings/game_rules/send_command_feedback/close_check"
     ]
 }

--- a/data/control/tags/functions/menu_close.json
+++ b/data/control/tags/functions/menu_close.json
@@ -2,6 +2,7 @@
     "values": [
         "control:menus/show/player_menu/close_check",
         "control:menus/show/game_settings/close_check",
-        "control:menus/show/game_rules/close_check"
+        "control:menus/show/game_rules/close_check",
+        "control:menus/game_settings/game_rules/commandblock_output/close_check"
     ]
 }

--- a/data/control/tags/functions/menu_init.json
+++ b/data/control/tags/functions/menu_init.json
@@ -3,6 +3,7 @@
         "control:menus/show/player_menu/initialize",
         "control:menus/show/game_settings/initialize",
         "control:menus/show/game_rules/initialize",
-        "control:menus/game_settings/game_rules/commandblock_output/initialize"
+        "control:menus/game_settings/game_rules/commandblock_output/initialize",
+        "control:menus/return/game_settings/initialize"
     ]
 }

--- a/data/control/tags/functions/menu_init.json
+++ b/data/control/tags/functions/menu_init.json
@@ -3,8 +3,6 @@
         "control:menus/show/player_menu/initialize",
         "control:menus/show/game_settings/initialize",
         "control:menus/show/game_rules/initialize",
-        "control:menus/show/player_menu/initialize",
-        "control:menus/show/game_settings/initialize",
-        "control:menus/show/game_rules/initialize"
+        "control:menus/game_settings/game_rules/commandblock_output/initialize"
     ]
 }

--- a/data/control/tags/functions/menu_init.json
+++ b/data/control/tags/functions/menu_init.json
@@ -4,6 +4,7 @@
         "control:menus/show/game_settings/initialize",
         "control:menus/show/game_rules/initialize",
         "control:menus/game_settings/game_rules/commandblock_output/initialize",
-        "control:menus/return/game_settings/initialize"
+        "control:menus/return/game_settings/initialize",
+        "control:menus/game_settings/game_rules/send_command_feedback/initialize"
     ]
 }

--- a/data/control/tags/functions/menu_modify.json
+++ b/data/control/tags/functions/menu_modify.json
@@ -3,6 +3,7 @@
         "control:menus/show/player_menu/modify_check",
         "control:menus/show/game_settings/modify_check",
         "control:menus/show/game_rules/modify_check",
-        "control:menus/game_settings/game_rules/commandblock_output/modify_check"
+        "control:menus/game_settings/game_rules/commandblock_output/modify_check",
+        "control:menus/return/game_settings/modify_check"
     ]
 }

--- a/data/control/tags/functions/menu_modify.json
+++ b/data/control/tags/functions/menu_modify.json
@@ -3,8 +3,6 @@
         "control:menus/show/player_menu/modify_check",
         "control:menus/show/game_settings/modify_check",
         "control:menus/show/game_rules/modify_check",
-        "control:menus/show/player_menu/modify_check",
-        "control:menus/show/game_settings/modify_check",
-        "control:menus/show/game_rules/modify_check"
+        "control:menus/game_settings/game_rules/commandblock_output/modify_check"
     ]
 }

--- a/data/control/tags/functions/menu_modify.json
+++ b/data/control/tags/functions/menu_modify.json
@@ -4,6 +4,7 @@
         "control:menus/show/game_settings/modify_check",
         "control:menus/show/game_rules/modify_check",
         "control:menus/game_settings/game_rules/commandblock_output/modify_check",
-        "control:menus/return/game_settings/modify_check"
+        "control:menus/return/game_settings/modify_check",
+        "control:menus/game_settings/game_rules/send_command_feedback/modify_check"
     ]
 }

--- a/data/control/tags/functions/menus.json
+++ b/data/control/tags/functions/menus.json
@@ -3,6 +3,7 @@
         "control:menus/show/player_menu/check",
         "control:menus/show/game_settings/check",
         "control:menus/show/game_rules/check",
-        "control:menus/game_settings/game_rules/commandblock_output/check"
+        "control:menus/game_settings/game_rules/commandblock_output/check",
+        "control:menus/return/game_settings/check"
     ]
 }

--- a/data/control/tags/functions/menus.json
+++ b/data/control/tags/functions/menus.json
@@ -4,6 +4,7 @@
         "control:menus/show/game_settings/check",
         "control:menus/show/game_rules/check",
         "control:menus/game_settings/game_rules/commandblock_output/check",
-        "control:menus/return/game_settings/check"
+        "control:menus/return/game_settings/check",
+        "control:menus/game_settings/game_rules/send_command_feedback/check"
     ]
 }

--- a/data/control/tags/functions/menus.json
+++ b/data/control/tags/functions/menus.json
@@ -3,8 +3,6 @@
         "control:menus/show/player_menu/check",
         "control:menus/show/game_settings/check",
         "control:menus/show/game_rules/check",
-        "control:menus/show/player_menu/check",
-        "control:menus/show/game_settings/check",
-        "control:menus/show/game_rules/check"
+        "control:menus/game_settings/game_rules/commandblock_output/check"
     ]
 }


### PR DESCRIPTION
ゲームルールの切り替えページ及び、`commandBlockOutput`、`sendCommandFeedback`の追加、ゲーム設定画面へ戻るためのアイコンを追加。  
戻るためのものは最後に反映するページやスロットを追加していくことでページごとに同じ役割のアイコンを追加する必要がなくなる。