### PR TITLE
Bug/no show menu

### DIFF
--- a/data/common/functions/define.mcfunction
+++ b/data/common/functions/define.mcfunction
@@ -2,6 +2,8 @@
 
 #> Storage
 #define storage common:
+# 外部ライブラリ - 個別用ストレージOhMyDat
+#define storage oh_my_dat:
 
 #> ScoreBoard-Objective
 #define objective Common
@@ -13,3 +15,7 @@
 
 #> LootTable
 #define loot_table common:player_name
+
+#> function
+# 外部ライブラリ - 個別用ストレージOhMyDat
+#define function oh_my_dat:please

--- a/data/control/functions/menu_apply.mcfunction
+++ b/data/control/functions/menu_apply.mcfunction
@@ -1,0 +1,6 @@
+#> control:menu_apply
+#
+# プレイヤーのOhMyDatにメニュー情報を格納する
+#
+
+data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Control.ShowMenu set from storage control:menu ShowMenu

--- a/data/control/functions/menu_item/click.mcfunction
+++ b/data/control/functions/menu_item/click.mcfunction
@@ -3,6 +3,9 @@
 # メニューがクリックされたら実行
 #
 
+## 個人用ストレージ呼び出し
+function oh_my_dat:please
+
 scoreboard players set @s CtrlEnderChest 0
 
 ## クリックサウンド

--- a/data/control/functions/menu_item/show.mcfunction
+++ b/data/control/functions/menu_item/show.mcfunction
@@ -9,7 +9,7 @@ function control:menu_item/clear
 ## ページアイテムを編集
 data remove storage control: Item
 data remove storage control:menu Modified
-data modify storage control: _ set from storage control:menu ShowMenu
+data modify storage control: _ set from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Control.ShowMenu
 function control:menu_item/modify
 
 ## シュルカーボックスにページ情報をセット

--- a/data/control/functions/menus/return/game_settings/act/0.mcfunction
+++ b/data/control/functions/menus/return/game_settings/act/0.mcfunction
@@ -5,3 +5,5 @@
 
 ## ゲーム設定画面にセット
 data modify storage control:menu ShowMenu set from storage control:menu Menus.GameSettings
+## 反映
+function control:menu_apply

--- a/data/control/functions/menus/return/select/act/0.mcfunction
+++ b/data/control/functions/menus/return/select/act/0.mcfunction
@@ -5,3 +5,5 @@
 
 ## セレクト画面にセット
 data modify storage control:menu ShowMenu set from storage control:menu Menus.Select
+## 反映
+function control:menu_apply

--- a/data/control/functions/menus/show/game_rules/act/0.mcfunction
+++ b/data/control/functions/menus/show/game_rules/act/0.mcfunction
@@ -6,3 +6,5 @@
 
 ## ゲームルール一覧を表示
 data modify storage control:menu ShowMenu set from storage control:menu Menus.GameRules
+## 反映
+function control:menu_apply

--- a/data/control/functions/menus/show/game_settings/act/0.mcfunction
+++ b/data/control/functions/menus/show/game_settings/act/0.mcfunction
@@ -6,3 +6,5 @@
 
 ## ゲーム設定メニューに変更
 data modify storage control:menu ShowMenu set from storage control:menu Menus.GameSettings
+## 反映
+function control:menu_apply

--- a/data/control/functions/menus/show/player_menu/act/0.mcfunction
+++ b/data/control/functions/menus/show/player_menu/act/0.mcfunction
@@ -6,3 +6,5 @@
 
 ## プレイヤーのメニューに変更
 data modify storage control:menu ShowMenu set from storage control:menu Menus.Player
+## 反映
+function control:menu_apply

--- a/data/control/functions/open-ender_chest.mcfunction
+++ b/data/control/functions/open-ender_chest.mcfunction
@@ -17,10 +17,12 @@ function control:menu_item/show
 tag @s add CtrlEnderChest
 
 ## メニュー操作tick起動
-schedule function control:tick 1t
+schedule function control:tick 1t replace
 
 ## close検知準備
 item replace entity @s armor.head with stone_button{EnderChestClose:true}
 
 scoreboard players reset @s CtrlEnderChest
 advancement revoke @s only control:open-ender_chest
+
+tellraw @a [{"selector":"@s"}," がメニューを開いた"]

--- a/data/control/functions/open-ender_chest.mcfunction
+++ b/data/control/functions/open-ender_chest.mcfunction
@@ -5,11 +5,16 @@
 # エンダーチェストを開けた時、設定画面を表示する。
 #
 
+## 個人用ストレージ呼び出し
+function oh_my_dat:please
+
 ## 開けた時、アイテムをセット
 #Not クリエイティブ
 execute if entity @s[gamemode=!creative] run data modify storage control:menu ShowMenu set from storage control:menu Menus.Player
 #クリエイティブ
 execute if entity @s[gamemode=creative] run data modify storage control:menu ShowMenu set from storage control:menu Menus.Select
+#反映
+function control:menu_apply
 #表示
 function control:menu_item/show
 
@@ -24,5 +29,3 @@ item replace entity @s armor.head with stone_button{EnderChestClose:true}
 
 scoreboard players reset @s CtrlEnderChest
 advancement revoke @s only control:open-ender_chest
-
-tellraw @a [{"selector":"@s"}," がメニューを開いた"]

--- a/data/control/functions/tick.mcfunction
+++ b/data/control/functions/tick.mcfunction
@@ -9,4 +9,4 @@ execute as @a[scores={CtrlEnderChest=1}] at @s run function control:menu_item/cl
 scoreboard players reset @a CtrlEnderChest
 
 ## tick loop
-execute if entity @a[tag=CtrlEnderChest] run schedule function control:tick 1t
+execute if entity @a[tag=CtrlEnderChest] run schedule function control:tick 2t replace


### PR DESCRIPTION
#6 と #7 のバグ修正

# #6 について
`control:tick`のループを1tickから2tickに変更することで動作確認。

# #7 について
複数人が`control:menu ShowMenu`を参照する方法から、それぞれのOhMyDat `oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Control.ShowMenu`に保存し参照するように変更。マルチ動作未確認。

これにより、外部ライブラリのOhMyDatの導入が必須となる。